### PR TITLE
Add env example and instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-api-key

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ pip install langchain openai faiss-cpu tiktoken
 
 If you want to run without OpenAI, replace `OpenAIEmbeddings` with `sentence-transformers` and use a local model.
 
+## Configuration
+
+Copy `.env.example` to `.env` and replace `your-api-key` with your OpenAI API key:
+
+```bash
+cp .env.example .env
+# edit .env and set your real key
+```
+
 ## Usage
 
 1. Populate `knowledge_base/` with your source documents.


### PR DESCRIPTION
## Summary
- add `.env.example` with OpenAI API key placeholder
- mention env configuration steps in README

## Testing
- `pytest -q`